### PR TITLE
Fix text input autofocusing

### DIFF
--- a/src/components/play/PlayPage.js
+++ b/src/components/play/PlayPage.js
@@ -13,11 +13,6 @@ export class PlayPage extends React.Component {
       level: defaultValues.level,
       answer: ''
     };
-    this.focus = this.focus.bind(this);
-  }
-
-  focus() {
-    this.textInput.focus();
   }
 
   checkAnswer() {
@@ -26,7 +21,10 @@ export class PlayPage extends React.Component {
     } else {
       this.setState(utils.generateStateByLevel(this.state.level, 'down'));
     }
-    this.focus();
+  }
+
+  componentDidMount() {
+    this.textInput.focus();
   }
 
   render() {


### PR DESCRIPTION
There's currently an issue with the text input, which won't autofocus until the very first submission. This isn't quite handy as the user would need to click on the text field initially rather than entering an answer right away. This PR addresses the issue by leveraging the `componentDidMount()` hook.

/cc @SmolinPavel 